### PR TITLE
Clean up locators code

### DIFF
--- a/base/expected_conditions.py
+++ b/base/expected_conditions.py
@@ -7,8 +7,8 @@ class link_has_href(object):
         self.locator = locator
 
     def __call__(self, driver):
-        element = EC.visibility_of_element_located(self.locator)(driver)
-        if element and element.get_property('href'):
-            return element
+        element_href = EC._find_element(driver, self.locator).get_attribute('href')
+        if element_href:
+            return element_href
         else:
             return False


### PR DESCRIPTION
## Purpose
The `locator` and `BaseElement` code was getting a little messy due to the growing number of locator types.


## Summary of Changes
This code adds a mandatory method `get_element` to all locators. This method is used in `__getattribute__` of `BaseElement` so that there no longer has to be a special case for different types of locators.

I also changed an argument throughout the locator code that used to be called `element` to `attribute_name`. This was to clarify that that argument was the name of the property created in the page object class.

## Testing Changes Moving Forward
Nothing in the actual tests should change. If any new locator classes are created (let's hope not) they would need a `get_element` method moving forward.

## Ticket
None
