### PR TITLE
Test to check if preprints search is functioning [QA-78]

### DIFF
--- a/pages/login.py
+++ b/pages/login.py
@@ -1,6 +1,7 @@
 from selenium.webdriver.common.by import By
 
 import settings
+from time import sleep
 from base.exceptions import LoginError
 from base.locators import Locator
 from pages.base import BasePage, OSFBasePage
@@ -37,6 +38,8 @@ class LoginPage(BasePage):
 def login(driver, user=settings.USER_ONE, password=settings.USER_ONE_PASSWORD):
     login_page = LoginPage(driver)
     login_page.goto()
+    if settings.DRIVER == 'Remote' and settings.DESIRED_CAP['browser'] == 'IE':
+        sleep(.5)
     login_page.submit_login(user, password)
 
 def safe_login(driver):

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -2,7 +2,7 @@ import settings
 
 from selenium.webdriver.common.by import By
 
-from base.locators import Locator, ComponentLocator
+from base.locators import Locator, ComponentLocator, GroupLocator
 from components.navbars import PreprintsNavbar
 from pages.base import OSFBasePage, GuidBasePage
 
@@ -16,6 +16,7 @@ class PreprintLandingPage(BasePreprintPage):
 
     identity = Locator(By.CSS_SELECTOR, '.ember-application .preprint-header', settings.LONG_TIMEOUT)
     add_preprint_button = Locator(By.CLASS_NAME, 'preprint-submit-button', settings.LONG_TIMEOUT)
+    search_button = Locator(By.CSS_SELECTOR, '.preprint-search .btn-default')
 
 
 class PreprintSubmitPage(BasePreprintPage):
@@ -55,6 +56,7 @@ class PreprintDiscoverPage(BasePreprintPage):
     url = settings.OSF_HOME + '/preprints/discover/'
 
     identity = Locator(By.ID, 'share-logo')
+    search_results = GroupLocator(By.CLASS_NAME, 'search-result')
 
 
 class PreprintDetailPage(GuidBasePage, BasePreprintPage):

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -5,7 +5,8 @@ from api import osf_api
 from pages.preprints import (
     PreprintLandingPage,
     PreprintSubmitPage,
-    PreprintDetailPage
+    PreprintDetailPage,
+    PreprintDiscoverPage,
 )
 
 
@@ -50,3 +51,9 @@ class TestPreprintWorkflow:
         submit_page.modal_create_preprint_button.click()
         PreprintDetailPage(driver, verify=True)
         # TODO: Make a clean way to check if you are on the correct project
+
+    @markers.core_functionality
+    def test_search_results_exist(self, driver, landing_page):
+        landing_page.search_button.click()
+        discover_page = PreprintDiscoverPage(driver, verify=True)
+        assert len(discover_page.search_results) > 0


### PR DESCRIPTION
## Purpose
My first preprints PR only had the default preprint workflow. Would be nice to also double check that Share is up and running for preprints. This PR adds that test.


## Summary of Changes
This test is checking the workflow an actual user would go through to get to the search page. If this doesn't seem like a worthwhile test, can cut out the first part where we click 'search' in order to get to the discover page and instead just navigate directly to the discover page.

I also found that there were a lot of strange errors logging in with IE. It seems it was sending the wrong keys for my username. It was suggested that sometimes IE needs to wait until certain things are fully loaded to send keys to an input. Change was added to wait an extra .5 when logging in in IE. This will hopefully be removed in the future.


## Testing Changes Moving Forward
IE tests are about 2.5 seconds slower, unfortunately. (And will get constantly slower with the addition of logged in tests)


## Ticket

https://openscience.atlassian.net/browse/QA-78
