### PR TITLE
Production smoke tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-- '3.6'
+  - '3.6'
 sudo: false
 env:
   global:
@@ -19,32 +19,27 @@ env:
   - secure: Hk6zGDMXfNgbrksYpbTOb26O24MhUmsH9C9vvsBGjiwpUubpjOzcWKoNZ40HPXjDUAPDW84tfGDiFr88gsfxIbcB6IoR9weuCI6RItQegHMXCxxSLnZgIOPoQbrl8IkiyDkLuej13yGdRYG5Q4HuGlVmvGluhxAa2J9+bkLdWbhxTJmRw9KMCfWJAcP3rI0EPkhfa+oqCbMZMZB1uwvYuMIrLK25PwI35e/NFuTInJ30QlSgLHdN4pP37f+FXxQW0ffxtEFdjIONb2ZwOXGPRWG2eW0s+w6S7oBwxRw0XQnwEG4PU700y0NNibsCFrXswkV4rSXZ+KebTXAzrCFefss8DV/AKQIRSv5tfqyGCycGlVPmqUBaTaSaXiZSEHEKmn7ZZq3STl6yJZnrsVSuQ0Cx4J2m06ZchBAL4cTDNy1FirTUoB/aRKEXpRweud5HrgVp9OdKTjUTfQLfbkqdB9MBUOUtxvgSJsbl1Ci4ikmT1fJp5YpqZmdK4nUnUV0yPTvelxHd+cEoRZVpu8293Vn8v/eAVFxYPotqToHzJYJFkUQPajqvtHN7yo+yPrsksaaNwYPnpY5DqiMv8X6tLf8Qcn0fbn32imMhAqaPdyUZ8rT+tM34BhzdiVHuf2yM56Hw1jUUrn2sm2OpYgkGPnbgTXCQD391LVdeJdrO6wQ=
   - secure: Ebmw6g99P65PAQgbPnx24wSME7I9NC6JcZ0greZuGyS5+WfjA2ga9T8FLNJ4NnSBUhypOwfL2E+pwL4+Wg0ezkqv0ruCtsvY+LjTphwKCWkYnmf5iYI+0RRi0cUucbHF8gcetMR8W1CKyvpnT1MZKxCS7EMJ1B7SIend/ShRRo6KKyzykUliQF6v+8aebjfp7zE9D/hsURu9UWDblM16KtsfmYCHVuYDvXfHovQq8oIXBM0YOn+sluZhnbmIzhToEGXbyMteTgEGWsCbHvQjf8v9GrvkyGLbH/jbLUXjDGpW8wx+dT5iTOWxrnLIopdixN2vuBQORX16soE4y82aTle3UFKWcCUJQToDS0lLPXaHzjSVIaMdq59gHNniTH7Kimp7I+VV6O2PjF+ae3ME5RIEvbnCqqFF8RNhBc0DGP7mEl0mcTfiFWDuwWM0Mlb889aHl10nKJWZ07fpe6HdqeSESHY9OOSGvlky2F3XlyN0Rg++kVaJUXPd2gxkQ6vhvH6SK2TNgc58CEC0Zj1iC2aQ2Op4xp05t1yA47IqGQ3kNGM4SJKLDYaUJLLfFpR+pxoiSgmRcSUpYzWhe+ZwO6uo1eYay7nhR7Q2nvHaumVvpCNXh33gdQ1PDPLVmUqEa3HEWvvKBXWQ1Mcbxmv1BygwrawrJXJBKBYAUVZ2brs=
   - secure: p4YHBqYM0LDI11n4jB6BApPw3KWN3WQY2P6v2HZPbSszAP3+yeB2ULYDjF2vhkFZP6apKPGlp0oeDqWHDFhJ2mx06xoMAUoj1WWkS18DTdepXjmkopeR6BFo6lR4b+ZeEAE35PeexWOsntERqlo9u8aJ23JUQ564ofdOgBAJIuZZo8ueFehbcDnNrnvC77jX4GTkhEh5Lwb7bz34Zg39mlIn8yLZG9yd93qrA1B6FX17n0fTBDbfbRrx10mPDLv9D9ErTXWskpllmhLS0hYAqE0Ygl0bkbdGA1zTuFcTXTa3RU+Sv1grQq6cXc/lVJA40qOPSqL80L0XLvr/W6+FcQAb8S2Y4Wan/CayXKruenNc08Vld7nR9o7yNR6GhqdD1VYK++uQOudqh+ZMAjuLt9U3r18o36RiJXsS5mSwqNN/UlYkBKEulcXGFogvAhCoA5Mhe+1MB9K/voHJAUpVADOylwFCqa2sbpJQj9l77jug2J8p6wP5nwbPW5x3c2T8cwZvfszNF1dUQy1ZgDBWimQXLTmkewwpKOkZJDJfaz2hnGP5yZhKyFE5gQ6GetkYQjwezmiEq6IOnCsrvtk17uQjONI5p2a2xP6CM3ln75G8ytI2fKRMu1Xz46Uh8/fQvvbIn5SnvhADIL0aB9qlVreQ9y6Y4vzmq2ZVaVbx8Ww=
-  matrix:
-      - TEST_BUILD="chrome"
-      - TEST_BUILD="firefox"
-      - TEST_BUILD="edge"
-      - TEST_BUILD="msie"
-      - TEST_BUILD="safari"
-matrix:
-  fast_finish: true
-  allow_failures:
-  - env: TEST_BUILD="safari"
+
 install:
   - cd $PROJECT_DIR
   - travis_retry pip install --upgrade pip
   - travis_retry pip install invoke==0.13.0
   - travis_retry invoke requirements
-stages:
-  - name: prod
-    if: branch = master
-  - name: default
-    if: branch != master
 jobs:
   include:
-    - stage: default
-      script: invoke test_travis_$TEST_BUILD
-    - stage: prod
+    - stage: "Prod smoke tests"
+      if: branch = master
       env:
         - DOMAIN='prod'
         - PREFERRED_NODE='ucrdq'
       script: invoke test_travis_on_prod
+    - if: branch != master
+      env: TEST_BUILD="chrome"
+    - if: branch != master
+      env: TEST_BUILD="firefox"
+    - if: branch != master
+      env: TEST_BUILD="edge"
+    - if: branch != master
+      env: TEST_BUILD="msie"
+script:
+  - invoke test_travis_$TEST_BUILD

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,19 +20,31 @@ env:
   - secure: Ebmw6g99P65PAQgbPnx24wSME7I9NC6JcZ0greZuGyS5+WfjA2ga9T8FLNJ4NnSBUhypOwfL2E+pwL4+Wg0ezkqv0ruCtsvY+LjTphwKCWkYnmf5iYI+0RRi0cUucbHF8gcetMR8W1CKyvpnT1MZKxCS7EMJ1B7SIend/ShRRo6KKyzykUliQF6v+8aebjfp7zE9D/hsURu9UWDblM16KtsfmYCHVuYDvXfHovQq8oIXBM0YOn+sluZhnbmIzhToEGXbyMteTgEGWsCbHvQjf8v9GrvkyGLbH/jbLUXjDGpW8wx+dT5iTOWxrnLIopdixN2vuBQORX16soE4y82aTle3UFKWcCUJQToDS0lLPXaHzjSVIaMdq59gHNniTH7Kimp7I+VV6O2PjF+ae3ME5RIEvbnCqqFF8RNhBc0DGP7mEl0mcTfiFWDuwWM0Mlb889aHl10nKJWZ07fpe6HdqeSESHY9OOSGvlky2F3XlyN0Rg++kVaJUXPd2gxkQ6vhvH6SK2TNgc58CEC0Zj1iC2aQ2Op4xp05t1yA47IqGQ3kNGM4SJKLDYaUJLLfFpR+pxoiSgmRcSUpYzWhe+ZwO6uo1eYay7nhR7Q2nvHaumVvpCNXh33gdQ1PDPLVmUqEa3HEWvvKBXWQ1Mcbxmv1BygwrawrJXJBKBYAUVZ2brs=
   - secure: p4YHBqYM0LDI11n4jB6BApPw3KWN3WQY2P6v2HZPbSszAP3+yeB2ULYDjF2vhkFZP6apKPGlp0oeDqWHDFhJ2mx06xoMAUoj1WWkS18DTdepXjmkopeR6BFo6lR4b+ZeEAE35PeexWOsntERqlo9u8aJ23JUQ564ofdOgBAJIuZZo8ueFehbcDnNrnvC77jX4GTkhEh5Lwb7bz34Zg39mlIn8yLZG9yd93qrA1B6FX17n0fTBDbfbRrx10mPDLv9D9ErTXWskpllmhLS0hYAqE0Ygl0bkbdGA1zTuFcTXTa3RU+Sv1grQq6cXc/lVJA40qOPSqL80L0XLvr/W6+FcQAb8S2Y4Wan/CayXKruenNc08Vld7nR9o7yNR6GhqdD1VYK++uQOudqh+ZMAjuLt9U3r18o36RiJXsS5mSwqNN/UlYkBKEulcXGFogvAhCoA5Mhe+1MB9K/voHJAUpVADOylwFCqa2sbpJQj9l77jug2J8p6wP5nwbPW5x3c2T8cwZvfszNF1dUQy1ZgDBWimQXLTmkewwpKOkZJDJfaz2hnGP5yZhKyFE5gQ6GetkYQjwezmiEq6IOnCsrvtk17uQjONI5p2a2xP6CM3ln75G8ytI2fKRMu1Xz46Uh8/fQvvbIn5SnvhADIL0aB9qlVreQ9y6Y4vzmq2ZVaVbx8Ww=
   matrix:
-  - TEST_BUILD="msie"
-  - TEST_BUILD="safari"
-  - TEST_BUILD="edge"
-  - TEST_BUILD="firefox"
-  - TEST_BUILD="chrome"
+      - TEST_BUILD="chrome"
+      - TEST_BUILD="firefox"
+      - TEST_BUILD="edge"
+      - TEST_BUILD="msie"
+      - TEST_BUILD="safari"
 matrix:
   fast_finish: true
   allow_failures:
   - env: TEST_BUILD="safari"
 install:
-- cd $PROJECT_DIR
-- travis_retry pip install --upgrade pip
-- travis_retry pip install invoke==0.13.0
-- travis_retry invoke requirements
-script:
-- invoke test_travis_$TEST_BUILD
+  - cd $PROJECT_DIR
+  - travis_retry pip install --upgrade pip
+  - travis_retry pip install invoke==0.13.0
+  - travis_retry invoke requirements
+stages:
+  - name: prod
+    if: branch = master
+  - name: default
+    if: branch != master
+jobs:
+  include:
+    - stage: default
+      script: invoke test_travis_$TEST_BUILD
+    - stage: prod
+      env:
+        - DOMAIN='prod'
+        - PREFERRED_NODE='ucrdq'
+      script: invoke test_travis_on_prod

--- a/markers.py
+++ b/markers.py
@@ -2,5 +2,8 @@ import pytest
 import settings
 
 #TODO: Is there a better place to put these?
+smoke_test = pytest.mark.smoke_test
 core_functionality = pytest.mark.core_functionality
 dont_run_on_prod = pytest.mark.skipif(settings.PRODUCTION, reason='Test should not run on production')
+dont_run_on_preferred_node = pytest.mark.skipif(bool(settings.PREFERRED_NODE),
+                                                reason='Test makes breaking changes to preferred node')

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,8 @@ filterwarnings =
     once::PendingDeprecationWarning
 
 markers =
+    smoke_test: mark a test as part os the small subset of tests to quickly smoke test a server.
     core_functionality: mark a test as a core OSF functionality test.
+    dont_run_on_prod: mark a test that creates public data to never run on production.
+    dont_run_on_preferred_node: mark a test that changes starting state of preferred node.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytest-xdist==1.15.0
 requests==2.5.3
 pythosf==0.0.9
 environs==3.0.0
+faker==0.9.0

--- a/settings.py
+++ b/settings.py
@@ -44,6 +44,7 @@ LONG_TIMEOUT = env.int('LONG_TIMEOUT', 30)
 
 DOMAIN = env('DOMAIN', 'stage1')
 
+# Preferred node must be set to run tests on production
 PREFERRED_NODE = env('PREFERRED_NODE', None)
 if DOMAIN == 'prod':
     PREFERRED_NODE = env('PREFERRED_NODE')
@@ -90,11 +91,3 @@ STAGE2 = DOMAIN == 'stage2'
 STAGE3 = DOMAIN == 'stage3'
 TEST = DOMAIN == 'test'
 PRODUCTION = DOMAIN == 'prod'
-
-# TODO: Change to add failsafe but not prohibit
-if PRODUCTION:
-    raise Exception(
-        'OSF UI tests should *never* be run against production. '
-        '(A large number of database entries and files are generated '
-        'during testing.)'
-    )

--- a/settings.py
+++ b/settings.py
@@ -73,7 +73,7 @@ if DRIVER == 'Remote':
     BSTACK_USER = env('BSTACK_USER')
     BSTACK_KEY = env('BSTACK_KEY')
 
-    BUILD = env('TEST_BUILD', 'firefox')
+    BUILD = env('TEST_BUILD', 'chrome')
     DESIRED_CAP = caps[BUILD]
 
     upper_build = BUILD.upper()

--- a/settings.py
+++ b/settings.py
@@ -30,7 +30,7 @@ domains = {
     'prod': {
         'home': 'https://osf.io',
         'api': 'https://api.osf.io',
-        'files': 'https://files.us.osf.io',
+        'files': 'https://files.osf.io',
         'cas': 'https://accounts.osf.io'
     }
 }

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -43,7 +43,7 @@ def requirements(ctx, dev=False):
     ctx.run(cmd, echo=True)
 
 @task
-def test_module(ctx, module=None, numprocesses=1, params=None):
+def test_module(ctx, module=None, numprocesses=1, params=None, marker=None):
     """Helper for running tests.
     """
     import pytest
@@ -55,11 +55,11 @@ def test_module(ctx, module=None, numprocesses=1, params=None):
     args = ['-s', '-v']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
-    modules = [module] if isinstance(module, str) else module
-    args.extend(modules)
-    if params:
-        params = [params] if isinstance(params, str) else params
-        args.extend(params)
+
+    for e in [module, marker, params]:
+        if e:
+            args.extend([e] if isinstance(e, str) else e)
+
     retcode = pytest.main(args)
     sys.exit(retcode)
 
@@ -70,7 +70,7 @@ def test_travis_safari(ctx, numprocesses=None):
     """
     flake(ctx)
     print('Testing modules in "{}" in Safari'.format('tests'))
-    test_module(ctx, module=['tests'])
+    test_module(ctx)
 
 @task
 def test_travis_chrome(ctx, numprocesses=None):
@@ -79,7 +79,7 @@ def test_travis_chrome(ctx, numprocesses=None):
     """
     flake(ctx)
     print('Testing modules in "{}" in Chrome'.format('tests'))
-    test_module(ctx, module=['tests'])
+    test_module(ctx)
 
 @task
 def test_travis_edge(ctx, numprocesses=None):
@@ -88,7 +88,7 @@ def test_travis_edge(ctx, numprocesses=None):
     """
     flake(ctx)
     print('Testing modules in "{}" in Edge'.format('tests'))
-    test_module(ctx, module=['tests'])
+    test_module(ctx)
 
 @task
 def test_travis_firefox(ctx, numprocesses=None):
@@ -97,7 +97,7 @@ def test_travis_firefox(ctx, numprocesses=None):
     """
     flake(ctx)
     print('Testing modules in "{}" in Firefox'.format('tests'))
-    test_module(ctx, module=['tests'])
+    test_module(ctx)
 
 @task
 def test_travis_msie(ctx, numprocesses=None):
@@ -106,7 +106,7 @@ def test_travis_msie(ctx, numprocesses=None):
     """
     flake(ctx)
     print('Testing modules in "{}" in MSIE'.format('tests'))
-    test_module(ctx, module=['tests'])
+    test_module(ctx)
 
 @task
 def test_travis_android(ctx, numprocesses=None):
@@ -115,7 +115,7 @@ def test_travis_android(ctx, numprocesses=None):
     """
     flake(ctx)
     print('Testing modules in "{}" in android'.format('tests'))
-    test_module(ctx, module=['tests'])
+    test_module(ctx)
 
 @task
 def test_travis_ios(ctx, numprocesses=None):
@@ -124,4 +124,13 @@ def test_travis_ios(ctx, numprocesses=None):
     """
     flake(ctx)
     print('Testing modules in "{}" on ios'.format('tests'))
-    test_module(ctx, module=['tests'])
+    test_module(ctx)
+
+@task
+def test_travis_on_prod(ctx, numprocesses=None):
+    """
+    Runs targeted prod smoke tests on the latest Chrome
+    """
+    flake(ctx)
+    print('Testing modules in "{}" in Chrome'.format('tests'))
+    test_module(ctx, marker='smoke_test')

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -43,7 +43,7 @@ def requirements(ctx, dev=False):
     ctx.run(cmd, echo=True)
 
 @task
-def test_module(ctx, module=None, numprocesses=1, params=None, marker=None):
+def test_module(ctx, module=None, numprocesses=1, params=None):
     """Helper for running tests.
     """
     import pytest
@@ -56,7 +56,7 @@ def test_module(ctx, module=None, numprocesses=1, params=None, marker=None):
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 
-    for e in [module, marker, params]:
+    for e in [module, params]:
         if e:
             args.extend([e] if isinstance(e, str) else e)
 
@@ -133,4 +133,4 @@ def test_travis_on_prod(ctx, numprocesses=None):
     """
     flake(ctx)
     print('Testing modules in "{}" in Chrome'.format('tests'))
-    test_module(ctx, marker='smoke_test')
+    test_module(ctx, module=['-m','smoke_test'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,9 +71,11 @@ def default_project(session):
 
 @pytest.fixture
 def project_with_file(session, default_project):
-    """
+    """Returns a project with a file.
+    Returns PREFERRED_NODE if it is set.
     """
     if settings.PREFERRED_NODE:
-        return osf_api.get_preferred_node(session)
-    osf_api.upload_fake_file(session, default_project)
+        osf_api.get_existing_file(session)
+    else:
+        osf_api.upload_fake_file(session, default_project)
     return default_project

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -2,7 +2,7 @@ import pytest
 import markers
 import settings
 
-from api import osf_api as osf
+from api import osf_api
 from pages.project import ProjectPage
 from pages.meetings import MeetingsPage
 from pages.preprints import PreprintLandingPage
@@ -17,6 +17,7 @@ def dashboard_page(driver, must_be_logged_in):
 
 class TestMainPage:
 
+    @markers.dont_run_on_prod
     @markers.core_functionality
     def test_create_project(self, driver, dashboard_page):
         title = 'New Project'
@@ -30,7 +31,7 @@ class TestMainPage:
         assert project_page.title.text == title, 'Project title incorrect.'
 
     def test_create_project_modal_buttons(self, dashboard_page, session):
-        institutions = osf.get_user_institutions(session)
+        institutions = osf_api.get_user_institutions(session)
         dashboard_page.create_project_button.click()
 
         create_project_modal = dashboard_page.create_project_modal
@@ -54,9 +55,10 @@ class TestMainPage:
 
         assert create_project_modal.modal.absent()
 
-    @pytest.mark.skipif(settings.STAGE3, reason='Works on new ember pages, not on stage3')
+    @markers.smoke_test
+    @markers.core_functionality
     def test_institution_logos(self, dashboard_page, session):
-        api_institution_names = osf.get_all_institutions(session)
+        api_institution_names = osf_api.get_all_institutions(session)
         page_institutions = dashboard_page.get_institutions()
         assert page_institutions, 'Institution logos missing.'
         page_institution_names = [i.get_property('name') for i in page_institutions]
@@ -75,25 +77,26 @@ class TestMainPage:
         dashboard_page.view_preprints_button.click()
         assert PreprintLandingPage(driver).verify()
 
+@markers.dont_run_on_prod
 @pytest.mark.usefixtures('must_be_logged_in')
 @pytest.mark.usefixtures('delete_user_projects_at_setup')
 class TestProjectList:
 
     @pytest.fixture()
     def project_one(self, session):
-        project_one = osf.create_project(session, title='&&aaaaaa')
+        project_one = osf_api.create_project(session, title='&&aaaaaa')
         yield project_one
         project_one.delete()
 
     @pytest.fixture()
     def project_two(self, session):
-        project_two = osf.create_project(session, title='&&aaaabb')
+        project_two = osf_api.create_project(session, title='&&aaaabb')
         yield project_two
         project_two.delete()
 
     @pytest.fixture()
     def project_three(self, session):
-        project_three = osf.create_project(session, title='&&aaaaac')
+        project_three = osf_api.create_project(session, title='&&aaaaac')
         yield project_three
         project_three.delete()
 

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -48,6 +48,7 @@ class TestPreprintWorkflow:
         preprint_detail = PreprintDetailPage(driver, verify=True)
         assert preprint_detail.title.text == project_with_file.title
 
+    @markers.smoke_test
     @markers.core_functionality
     def test_search_results_exist(self, driver, landing_page):
         landing_page.search_button.click()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -19,9 +19,10 @@ def project_page_with_file(driver, project_with_file):
 @pytest.mark.usefixtures('must_be_logged_in')
 class TestProjectDetailPage:
 
+    @markers.smoke_test
     @markers.core_functionality
-    def test_change_title(self, project_page):
-        new_title = 'New Day. New Title.'
+    def test_change_title(self, project_page, fake):
+        new_title = fake.sentence(nb_words=4)
         assert project_page.title.text != new_title
         project_page.title.click()
         project_page.title_input.clear()
@@ -29,6 +30,7 @@ class TestProjectDetailPage:
         project_page.title_edit_submit_button.click()
         assert project_page.title.text == new_title
 
+    @markers.smoke_test
     @markers.core_functionality
     def test_file_widget_loads(self, project_page_with_file):
         # Check the uploaded file shows up in the files widget
@@ -42,6 +44,7 @@ class TestProjectDetailPage:
         login(driver)
 
     @markers.dont_run_on_prod
+    @markers.dont_run_on_preferred_node
     @markers.core_functionality
     def test_make_public(self, driver, project_page):
         # Set project to public


### PR DESCRIPTION
## Purpose
Create a small set of smoke tests that can be run daily on production.


## Summary of Changes
- Add `smoke_test` marker. This is for a very small set of tests to be run to check general functioning.
- Added `PREFERRED_NODE` environment variable. It allows tests to be run all on the same node - preserving guids. Tests cannot be run on production without `PREFERRED_NODE` being set.
- Added `dont_run_on_preferred_node` marker to stop changes to the `PREFERRED_NODE` that may effect other tests. This is hopefully temporary.
- Added `faker` so it's now easy to create randomized titles.


## Testing Changes Moving Forward
- Will have to make considerations for `PREFERRED_NODE` when adding more tests to the smoke tests.
- There are some tests missing from our `smoke_test`s we still need a V2 action on a node that's not making it public and checking OSF search is working as expected.


## Ticket

https://openscience.atlassian.net/browse/QA-107
