### PR TITLE
Add log widget test

### DIFF
--- a/components/project.py
+++ b/components/project.py
@@ -1,8 +1,15 @@
 from selenium.webdriver.common.by import By
-from base.locators import GroupLocator, BaseElement
+from base.locators import Locator, GroupLocator, BaseElement
 
 
 class FileWidget(BaseElement):
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
 
     # Group Locators
     component_and_file_titles = GroupLocator(By.CSS_SELECTOR, '.td-title')
+
+class LogWidget(BaseElement):
+    loading_indicator = Locator(By.CSS_SELECTOR, '#logFeed .ball-scale')
+
+    # Group Locators
+    log_items = GroupLocator(By.CSS_SELECTOR, '#logFeed .db-activity-item')

--- a/pages/project.py
+++ b/pages/project.py
@@ -2,7 +2,7 @@ import settings
 
 from selenium.webdriver.common.by import By
 
-from components.project import FileWidget
+from components.project import FileWidget, LogWidget
 from pages.base import GuidBasePage, OSFBasePage
 from base.locators import Locator, ComponentLocator
 
@@ -20,6 +20,7 @@ class ProjectPage(GuidBasePage):
 
     # Components
     file_widget = ComponentLocator(FileWidget)
+    log_widget = ComponentLocator(LogWidget)
 
 
 class MyProjectsPage(OSFBasePage):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -28,13 +28,20 @@ class TestProjectDetailPage:
         project_page.title_input.clear()
         project_page.title_input.send_keys(new_title)
         project_page.title_edit_submit_button.click()
+        project_page.verify()  # Wait for the page to reload
         assert project_page.title.text == new_title
 
     @markers.smoke_test
     @markers.core_functionality
     def test_file_widget_loads(self, project_page_with_file):
         # Check the uploaded file shows up in the files widget
+        project_page_with_file.file_widget.loading_indicator.here_then_gone()
         assert project_page_with_file.file_widget.component_and_file_titles[3]
+
+    @markers.core_functionality
+    def test_log_widget_loads(self, project_page):
+        project_page.log_widget.loading_indicator.here_then_gone()
+        assert project_page.log_widget.log_items
 
     @markers.core_functionality
     def test_is_private(self, driver, project_page):


### PR DESCRIPTION



## Purpose
Add log widget test and clean up file widget test.


## Summary of Changes
Add wait in `test_file_widget_loads` for loading indicator.
Add wait for page reload in `test_change_title`.


## Testing Changes Moving Forward
In the future, make sure to account for loading indicators.


## Ticket

https://openscience.atlassian.net/browse/QA-76
