### PR TITLE
Add custom preprint domain tests [QA-98]

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -82,3 +82,11 @@ def upload_fake_file(session, node, name='osf selenium test file for testing bec
     session.put(url='{}/v1/resources/{}/providers/osfstorage/'.format(settings.FILE_DOMAIN, node.id),
                     query_parameters={'kind': 'file', 'name': name}, raw_body={})
     return name
+
+def get_providers_list(session=None, type='preprints'):
+    """Return the providers list data. The default is the preprint providers list.
+    """
+    if not session:
+        session = client.Session(api_base_url=settings.API_DOMAIN)
+    url = '/v2/providers/' + type
+    return session.get(url)['data']

--- a/components/navbars.py
+++ b/components/navbars.py
@@ -39,6 +39,7 @@ class AbstractLegacyEmberNavbar(Navbar):
 
 
 class PreprintsNavbar(AbstractLegacyEmberNavbar):
+    title = Locator(By.CSS_SELECTOR, '.navbar-title')
     add_a_preprint_link = Locator(By.CSS_SELECTOR, '#secondary-navigation > ul > li:nth-last-child(5) > a')
 
     def verify(self):

--- a/pages/base.py
+++ b/pages/base.py
@@ -17,6 +17,7 @@ class BasePage(BaseElement):
 
     def __init__(self, driver, verify=False):
         super().__init__(driver)
+
         if verify:
             self.check_page()
 
@@ -75,10 +76,7 @@ class OSFBasePage(BasePage):
     navbar = ComponentLocator(HomeNavbar)
 
     def __init__(self, driver, verify=False):
-        super().__init__(driver)
-
-        if verify:
-            self.check_page()
+        super().__init__(driver, verify)
 
     @property
     def error_heading(self):
@@ -105,15 +103,13 @@ class OSFBasePage(BasePage):
 
 
 class GuidBasePage(OSFBasePage):
-    base_url = urllib.parse.urljoin(settings.OSF_HOME, '{guid}')
 
-    def __init__(self, driver, verify=False, guid=''):
+    def __init__(self, driver, verify=False, guid='', domain=settings.OSF_HOME):
         super().__init__(driver, verify)
+        self.domain = domain
         self.guid = guid
 
     @property
     def url(self):
-        if '{guid}' in self.base_url:
-            return self.base_url.format(guid=self.guid)
-        else:
-            raise ValueError('No space in base_url for GUID specified.')
+        base_url = urllib.parse.urljoin(self.domain, '{guid}')
+        return base_url.format(guid=self.guid)


### PR DESCRIPTION
## Purpose
Add core tests for branded preprints. This mostly involves checking if branded pages load.


## Summary of Changes
- Add a fixture for grabbing all preprint providers
- Add a fixture for grabbing all providers with custom domains
- Add tests for the landing, discover, submit, and detail pages.


## Testing Changes Moving Forward
There are some changes to the preprint base pages that we may need to keep an eye on. The construction of branded urls is currently pretty fragile and convoluted.

It would also be nice moving forward to moving providers into pythosf rather than doing unprotected dictionary access of the API data received.


## Ticket

https://openscience.atlassian.net/browse/QA-98
