### PR TITLE
Add create user test [QA-118]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ USER_ONE_PASSWORD = 'CHANGEME'
 
 USER_TWO = 'CHANGEME'
 USER_TWO_PASSWORD = 'CHANGEME'
+
+# Email used for creaing new users. Email should be in the form email+{}@gmail.com in order to make unique emails.
+NEW_USER_EMAIL = 'CHANGEME'

--- a/pages/base.py
+++ b/pages/base.py
@@ -67,6 +67,10 @@ class BasePage(BaseElement):
         ActionChains(self.driver).drag_and_drop(source_element, dest_element).perform()
         # Note: If you close the browser too quickly, the drag/drop may not go through
 
+    def click_recaptcha(self):
+        self.driver.switch_to.frame(self.driver.find_element_by_tag_name('iframe'))
+        self.driver.find_element_by_css_selector('.recaptcha-checkbox-checkmark').click()
+        self.driver.switch_to.default_content()
 
 class OSFBasePage(BasePage):
     """

--- a/pages/base.py
+++ b/pages/base.py
@@ -1,6 +1,7 @@
 import settings
 
 import urllib.parse
+from time import sleep
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
@@ -71,6 +72,8 @@ class BasePage(BaseElement):
         self.driver.switch_to.frame(self.driver.find_element_by_tag_name('iframe'))
         self.driver.find_element_by_css_selector('.recaptcha-checkbox-checkmark').click()
         self.driver.switch_to.default_content()
+        #TODO: Replace with an expected condition that checks if aria-checked="true"
+        sleep(1)
 
 class OSFBasePage(BasePage):
     """

--- a/pages/base.py
+++ b/pages/base.py
@@ -70,7 +70,7 @@ class BasePage(BaseElement):
 
     def click_recaptcha(self):
         self.driver.switch_to.frame(self.driver.find_element_by_tag_name('iframe'))
-        self.driver.find_element_by_css_selector('.recaptcha-checkbox-checkmark').click()
+        Locator(By.CSS_SELECTOR, '.recaptcha-checkbox-checkmark').get_element(self.driver, 'capcha').click()
         self.driver.switch_to.default_content()
         #TODO: Replace with an expected condition that checks if aria-checked="true"
         sleep(1)

--- a/pages/landing.py
+++ b/pages/landing.py
@@ -26,3 +26,8 @@ class LegacyLandingPage(OSFBasePage):
     waffle_override = {'ember_home_page': LandingPage}
 
     identity = Locator(By.ID, 'home-hero', settings.LONG_TIMEOUT)
+
+class RegisteredReportsLandingPage(OSFBasePage):
+    url = settings.OSF_HOME + '/rr/'
+
+    identity = Locator(By.CSS_SELECTOR, '.reg-landing-page-logo')

--- a/pages/landing.py
+++ b/pages/landing.py
@@ -10,6 +10,14 @@ from base.locators import Locator, ComponentLocator
 class LandingPage(OSFBasePage):
     identity = Locator(By.ID, 'home-hero', settings.LONG_TIMEOUT)
 
+    name_input = Locator(By.CSS_SELECTOR, '#fullName')
+    email_one_input = Locator(By.CSS_SELECTOR, '#email1')
+    email_two_input = Locator(By.CSS_SELECTOR, '#email2')
+    password_input = Locator(By.CSS_SELECTOR, '#password')
+    terms_of_service_checkbox = Locator(By.CSS_SELECTOR, '#acceptedTermsOfService')
+    sign_up_button = Locator(By.CSS_SELECTOR, '._SignUpForm_3ntsx4 .btn-success')
+    registration_success = Locator(By.CSS_SELECTOR, '.ext-success', settings.LONG_TIMEOUT)
+
     # Components
     navbar = ComponentLocator(EmberNavbar)
 

--- a/pages/landing.py
+++ b/pages/landing.py
@@ -10,11 +10,11 @@ from base.locators import Locator, ComponentLocator
 class LandingPage(OSFBasePage):
     identity = Locator(By.ID, 'home-hero', settings.LONG_TIMEOUT)
 
-    name_input = Locator(By.CSS_SELECTOR, '#fullName')
-    email_one_input = Locator(By.CSS_SELECTOR, '#email1')
-    email_two_input = Locator(By.CSS_SELECTOR, '#email2')
-    password_input = Locator(By.CSS_SELECTOR, '#password')
-    terms_of_service_checkbox = Locator(By.CSS_SELECTOR, '#acceptedTermsOfService')
+    name_input = Locator(By.NAME, 'fullName')
+    email_one_input = Locator(By.NAME, 'email1')
+    email_two_input = Locator(By.NAME, 'email2')
+    password_input = Locator(By.NAME, 'password')
+    terms_of_service_checkbox = Locator(By.NAME, 'acceptedTermsOfService')
     sign_up_button = Locator(By.CSS_SELECTOR, '._SignUpForm_3ntsx4 .btn-success')
     registration_success = Locator(By.CSS_SELECTOR, '.ext-success', settings.LONG_TIMEOUT)
 

--- a/pages/landing.py
+++ b/pages/landing.py
@@ -14,7 +14,7 @@ class LandingPage(OSFBasePage):
     email_one_input = Locator(By.NAME, 'email1')
     email_two_input = Locator(By.NAME, 'email2')
     password_input = Locator(By.NAME, 'password')
-    terms_of_service_checkbox = Locator(By.NAME, 'acceptedTermsOfService')
+    terms_of_service_checkbox = Locator(By.CSS_SELECTOR, '#ember80__acceptedTermsOfService')
     sign_up_button = Locator(By.CSS_SELECTOR, '._SignUpForm_3ntsx4 .btn-success')
     registration_success = Locator(By.CSS_SELECTOR, '.ext-success', settings.LONG_TIMEOUT)
 

--- a/settings.py
+++ b/settings.py
@@ -99,11 +99,9 @@ CUSTOM_INSTITUTION_DOMAINS = domains[DOMAIN]['custom_institution_domains']
 # Browser capabilities for browserstack testing
 caps = {
     'chrome':
-        {'browser': 'Chrome', 'os': 'Windows', 'os_version': '10',
-               'resolution': '2048x1536'},
+        {'browser': 'Chrome', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536'},
     'edge': {'browser': 'Edge', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536', 'browser_version': '17.0'},
-    'firefox': {'os': 'OS X', 'os_version': 'Sierra', 'browser': 'Firefox',
-                'browserstack.geckodriver': '0.18.0'},
+    'firefox': {'browser': 'Firefox', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536'},
     'msie': {'browser': 'IE', 'browser_version': '11', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536'},
     'android': {'device': 'Samsung Galaxy S8', 'realMobile': 'true', 'os_version': '7.0'},
     'ios': {'device': 'iPhone 7', 'realMobile': 'true', 'os_version': '10.0'},

--- a/settings.py
+++ b/settings.py
@@ -66,6 +66,8 @@ VERY_LONG_TIMEOUT = env.int('VERY_LONG_TIMEOUT', 60)
 
 DOMAIN = env('DOMAIN', 'stage1')
 
+NEW_USER_EMAIL = env('NEW_USER_EMAIL')
+
 # Preferred node must be set to run tests on production
 PREFERRED_NODE = env('PREFERRED_NODE', None)
 if DOMAIN == 'prod':

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -15,7 +15,7 @@ def dashboard_page(driver, must_be_logged_in):
     return dashboard_page
 
 
-class TestMainPage:
+class TestDashboardPage:
 
     @markers.dont_run_on_prod
     @markers.core_functionality

--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -2,7 +2,7 @@ import pytest
 import markers
 import settings
 
-from pages.landing import LandingPage
+from pages.landing import LandingPage, RegisteredReportsLandingPage
 
 @pytest.fixture()
 def landing_page(driver):
@@ -32,3 +32,11 @@ class TestLandingPage:
         landing_page.click_recaptcha()
         landing_page.sign_up_button.click()
         assert landing_page.registration_success.present()
+
+
+class TestRegisteredReportsLandingPage:
+
+    @markers.core_functionality
+    def test_landing_page(self, driver):
+        landing_page = RegisteredReportsLandingPage(driver)
+        landing_page.goto()

--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -13,10 +13,10 @@ def landing_page(driver):
 
 class TestLandingPage:
 
-    @pytest.mark.skip(reason='These tests will not work until the new sign up page comes out. h/t James!')
     @markers.dont_run_on_prod
+    @pytest.mark.skipif(settings.TEST, reason='There is a real recapcha on test. Robots cannot create users there.')
     @markers.core_functionality
-    def test_create_user(self, driver, landing_page, fake):
+    def test_create_user(self, landing_page, fake):
 
         name = fake.name()
         email = settings.NEW_USER_EMAIL.format(''.join(name.split()))  # Add name with no spaces to end of email
@@ -26,5 +26,6 @@ class TestLandingPage:
         landing_page.email_two_input.send_keys(email)
         landing_page.password_input.send_keys(password)
         landing_page.terms_of_service_checkbox.click()
+        landing_page.click_recaptcha()
         landing_page.sign_up_button.click()
         assert landing_page.registration_success.present()

--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -21,6 +21,9 @@ class TestLandingPage:
         name = fake.name()
         email = settings.NEW_USER_EMAIL.format(''.join(name.split()))  # Add name with no spaces to end of email
         password = fake.sentence()
+
+        landing_page.scroll_into_view(landing_page.sign_up_button.element)
+
         landing_page.name_input.send_keys(name)
         landing_page.email_one_input.send_keys(email)
         landing_page.email_two_input.send_keys(email)

--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -1,0 +1,30 @@
+import pytest
+import markers
+import settings
+
+from pages.landing import LandingPage
+
+@pytest.fixture()
+def landing_page(driver):
+    landing_page = LandingPage(driver)
+    landing_page.goto()
+    return landing_page
+
+
+class TestLandingPage:
+
+    @pytest.mark.skip(reason='These tests will not work until the new sign up page comes out. h/t James!')
+    @markers.dont_run_on_prod
+    @markers.core_functionality
+    def test_create_user(self, driver, landing_page, fake):
+
+        name = fake.name()
+        email = settings.NEW_USER_EMAIL.format(''.join(name.split()))  # Add name with no spaces to end of email
+        password = fake.sentence()
+        landing_page.name_input.send_keys(name)
+        landing_page.email_one_input.send_keys(email)
+        landing_page.email_two_input.send_keys(email)
+        landing_page.password_input.send_keys(password)
+        landing_page.terms_of_service_checkbox.click()
+        landing_page.sign_up_button.click()
+        assert landing_page.registration_success.present()


### PR DESCRIPTION
## Purpose
Add a test for creating a user. (This one's currently for the landing page, but replace with a generic one once the generic sign up exists)


## Summary of Changes
Add test that creates a user. Can only be run on the stagings (not on test or prod). 

Also pop in the registered reports landing page loading test.


## Testing Changes Moving Forward
None


## Ticket

https://openscience.atlassian.net/browse/QA-118
https://openscience.atlassian.net/browse/QA-93