### PR TITLE
Add special case for send_keys in IE

### DIFF
--- a/base/expected_conditions.py
+++ b/base/expected_conditions.py
@@ -1,5 +1,6 @@
 from selenium.webdriver.support import expected_conditions as EC
 
+
 class link_has_href(object):
     """ An Expectation for checking link is visible and has an href so
     you can click it."""
@@ -22,3 +23,25 @@ class window_at_index(object):
 
     def __call__(self, driver):
         return len(driver.window_handles) > self.page_index
+
+
+class correct_keys_sent(object):
+    """ An Exception used for checking if the correct keys have been sent to an input.
+    This is used for repeatedly attempting to send keys to IE because sometimes it sends the
+    incorrect keys.
+
+    Note: This is not a great example of an expected condition because it changes what's on the page.
+    """
+    def __init__(self, element, keys, existing_keys):
+        self.element = element
+        self.keys = keys
+        self.correct_keys = existing_keys + keys
+
+    def __call__(self, driver):
+
+        if self.element.get_attribute('value') == self.correct_keys:
+            return True
+        else:
+            self.element.clear()
+            self.element.send_keys(self.correct_keys)
+            return False

--- a/pages/login.py
+++ b/pages/login.py
@@ -1,7 +1,6 @@
 from selenium.webdriver.common.by import By
 
 import settings
-from time import sleep
 from base.exceptions import LoginError
 from base.locators import Locator
 from pages.base import BasePage, OSFBasePage
@@ -38,8 +37,6 @@ class LoginPage(BasePage):
 def login(driver, user=settings.USER_ONE, password=settings.USER_ONE_PASSWORD):
     login_page = LoginPage(driver)
     login_page.goto()
-    if settings.DRIVER == 'Remote' and settings.DESIRED_CAP['browser'] == 'IE':
-        sleep(.5)
     login_page.submit_login(user, password)
 
 def safe_login(driver):

--- a/tests/test_meetings.py
+++ b/tests/test_meetings.py
@@ -34,8 +34,7 @@ class TestMeetingsPage:
     def test_filtering(self, meetings_page):
         default_top_result = meetings_page.top_meeting_link.text
         meetings_page.filter_input.clear()
-        meetings_page.filter_input.send_keys('e')
-        meetings_page.filter_input.send_keys('a')  # TODO: Remove this, hack to make IE work
+        meetings_page.filter_input.send_keys('ea')
         filtered_top_result = meetings_page.top_meeting_link.text
         assert default_top_result != filtered_top_result
 


### PR DESCRIPTION
## Purpose
In IE, selenium sometimes sends the wrong keys. Selenium said this was fixed. [It's not](https://github.com/SeleniumHQ/selenium/issues/4462#issuecomment-327181851). And I just want my tests to pass.


## Summary of Changes
Give locators their own `send_keys` so that it can send keys to IE over and over again until they're the correct keys. You know, like an insane person. Don't worry, it eventually times out and gives up.


## Testing Changes Moving Forward
Hopefully will be easier moving forward for things to pass in IE. The lovely part is now an error is raised that will let me know if the tests failed because of this problem.


## Ticket
 Nope
