### PR TITLE
Add production smoke test for addons

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -70,6 +70,16 @@ def delete_all_user_projects(session, user=None):
             n.get()
             n.delete()
 
+def get_node_addons(session, node_id):
+    """Return a list of the names of all the addons connected to the given node.
+    """
+    url = '/v2/nodes/{}/files/'.format(node_id)
+    data = session.get(url)
+    providers = []
+    for provider in data['data']:
+        providers.append(provider['attributes']['provider'])
+    return providers
+
 def waffled_pages(session):
     waffle_list = []
     url = '/v2/_waffle/'

--- a/components/project.py
+++ b/components/project.py
@@ -4,6 +4,9 @@ from base.locators import Locator, GroupLocator, BaseElement
 
 class FileWidget(BaseElement):
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+    file_expander = Locator(By.CSS_SELECTOR, '.fa-plus')
+    filter_button = Locator(By.CSS_SELECTOR, '.fangorn-toolbar-icon .fa-search')
+    filter_input = Locator(By.CSS_SELECTOR, '#folderRow .form-control')
 
     # Group Locators
     component_and_file_titles = GroupLocator(By.CSS_SELECTOR, '.td-title')

--- a/settings.py
+++ b/settings.py
@@ -49,6 +49,23 @@ PREFERRED_NODE = env('PREFERRED_NODE', None)
 if DOMAIN == 'prod':
     PREFERRED_NODE = env('PREFERRED_NODE')
 
+EXPECTED_PROVIDERS = env.list(
+    'EXPECTED_PROVIDERS',
+    [
+        # 'bitbucket',
+        'box',
+        'dataverse',
+        'dropbox',
+        'figshare',
+        'github',
+        'gitlab',
+        'googledrive',
+        'osfstorage',
+        # 'owncloud',
+        'onedrive',
+        's3'
+    ])
+
 OSF_HOME = domains[DOMAIN]['home']
 API_DOMAIN = domains[DOMAIN]['api']
 FILE_DOMAIN = domains[DOMAIN]['files']

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,6 +1,8 @@
 import pytest
-import markers
 
+import markers
+import settings
+from api import osf_api
 from pages.project import ProjectPage
 from pages.login import login, logout
 
@@ -31,13 +33,6 @@ class TestProjectDetailPage:
         project_page.verify()  # Wait for the page to reload
         assert project_page.title.text == new_title
 
-    @markers.smoke_test
-    @markers.core_functionality
-    def test_file_widget_loads(self, project_page_with_file):
-        # Check the uploaded file shows up in the files widget
-        project_page_with_file.file_widget.loading_indicator.here_then_gone()
-        assert project_page_with_file.file_widget.component_and_file_titles[3]
-
     @markers.core_functionality
     def test_log_widget_loads(self, project_page):
         project_page.log_widget.loading_indicator.here_then_gone()
@@ -62,3 +57,30 @@ class TestProjectDetailPage:
         logout(driver)
         project_page.goto()
         login(driver)
+
+    @markers.smoke_test
+    @markers.core_functionality
+    def test_file_widget_loads(self, project_page_with_file):
+        # Check the uploaded file shows up in the files widget
+        project_page_with_file.file_widget.loading_indicator.here_then_gone()
+        assert project_page_with_file.file_widget.component_and_file_titles[3]
+
+    @markers.smoke_test
+    @pytest.mark.skipif(not settings.PREFERRED_NODE, reason='Only run this test if addons are set up on a specific node.')
+    def test_addon_files_load(self, project_page, session, driver):
+        """This test is very fragile and makes assumptions about your setup.
+        You must have all of the addons in `EXPECTED_PROVIDERS` connected to your `PREFERRED_NODE`.
+        In each provider you must have a file named `<provider_name>.txt`.
+
+        The test will fail if you do not have the expected providers connected.
+        The test will also fail if you have not named your files correctly.
+        """
+        providers = osf_api.get_node_addons(session, project_page.guid)
+        assert set(providers) == set(settings.EXPECTED_PROVIDERS)
+        project_page.file_widget.loading_indicator.here_then_gone()
+        project_page.file_widget.file_expander.here_then_gone()
+        project_page.file_widget.filter_button.click()
+        for provider in providers:
+            project_page.file_widget.filter_input.clear()
+            project_page.file_widget.filter_input.send_keys(provider)
+            driver.find_element_by_xpath("//*[contains(text(), '{}')]".format(provider + '.txt'))


### PR DESCRIPTION
## Purpose
This will add a smoke test for the addons. It will use a node that is already connected to all the addons (or however many are working for us right now) and check if files from those addons still load. That way, if an addon stops working, we'll know within the day.


## Summary of Changes
Add prod addons test.


## Testing Changes Moving Forward
These tests will also fail when authentication for an addon needs to be redone. This will need to be done manually.


## Ticket

None
